### PR TITLE
Update module.xml defining module dependencies

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -14,5 +14,9 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="KiwiCommerce_CronScheduler" setup_version="1.0.2" active="true" />
+    <module name="KiwiCommerce_CronScheduler" setup_version="1.0.2" active="true">
+        <sequence>
+            <module name="Magento_Cron"/>
+        </sequence>
+    </module>
 </config>


### PR DESCRIPTION
This module is dependant on the Magento_Cron module. Therefore the dependency should be defined in the module.xml.
If it is not defined the setup:install command will fail, due to the cron_schedule table not being present.