### PR TITLE
fix usort return deprecated on php 8.1

### DIFF
--- a/Ui/DataProvider/JobProvider.php
+++ b/Ui/DataProvider/JobProvider.php
@@ -120,9 +120,9 @@ class JobProvider extends \Magento\Ui\DataProvider\AbstractDataProvider
         $sortDir = $this->sortDir;
         usort($data, function ($a, $b) use ($sortField, $sortDir) {
             if ($sortDir == "asc") {
-                return $a[$sortField] > $b[$sortField];
+                return $a[$sortField] <=> $b[$sortField];
             } else {
-                return $a[$sortField] < $b[$sortField];
+                return $b[$sortField] <=> $a[$sortField];
             }
         });
 


### PR DESCRIPTION
From PHP 8.1 onwards, this approach is no longer allowed. To ensure sorting works correctly, the comparison function must return an integer.

![image](https://github.com/user-attachments/assets/8fd855cc-3cdf-45b2-9c33-d18a7d41353c)
