### PR TITLE
fix null passing to strtotime() on php8.1

### DIFF
--- a/Helper/Schedule.php
+++ b/Helper/Schedule.php
@@ -140,7 +140,8 @@ class Schedule extends \Magento\Framework\App\Helper\AbstractHelper
         } else {
             $currentTime = (int)$this->datetime->date('U') + $this->datetime->getGmtOffset('hours') * 60 * 60;
         }
-        $lastCronStatus = strtotime($this->scheduleCollectionFactory->create()->getLastCronStatus());
+        $lastCronStatusString = $this->scheduleCollectionFactory->create()->getLastCronStatus();
+        $lastCronStatus = $lastCronStatusString !== null ? strtotime($lastCronStatusString) : null;
         if ($lastCronStatus != null) {
             $diff = floor(($currentTime - $lastCronStatus) / 60);
             if ($diff > 5) {


### PR DESCRIPTION
When clicking on **System > Cron Scheduler by Kiwi Commerce > [All Menu]**, the following error occurs.

![image](https://github.com/user-attachments/assets/d51d0eda-cb00-4fa7-9f81-4a2a4ec4b2c6)

In PHP 8.1, passing `null` to `strtotime()` is no longer allowed. To resolve this issue, you need to check if the value passed to `strtotime()` is `null` and add logic to handle it appropriately.

