### PR TITLE
Add missing argument in ProcessCronQueueObserver constructor

### DIFF
--- a/Block/Adminhtml/Schedule/Timeline.php
+++ b/Block/Adminhtml/Schedule/Timeline.php
@@ -132,23 +132,13 @@ class Timeline extends \Magento\Backend\Block\Template
      */
     private function getStatusLevel($status)
     {
-        switch ($status) {
-            case \Magento\Cron\Model\Schedule::STATUS_ERROR:
-            case \Magento\Cron\Model\Schedule::STATUS_MISSED:
-                $level = 'major';
-                break;
-            case \Magento\Cron\Model\Schedule::STATUS_RUNNING:
-                $level = 'running';
-                break;
-            case \Magento\Cron\Model\Schedule::STATUS_PENDING:
-                $level = 'minor';
-                break;
-            case \Magento\Cron\Model\Schedule::STATUS_SUCCESS:
-                $level = 'notice';
-                break;
-            default:
-                $level = 'critical';
-        }
+        $level = match ($status) {
+            \Magento\Cron\Model\Schedule::STATUS_ERROR, \Magento\Cron\Model\Schedule::STATUS_MISSED => 'major',
+            \Magento\Cron\Model\Schedule::STATUS_RUNNING => 'running',
+            \Magento\Cron\Model\Schedule::STATUS_PENDING => 'minor',
+            \Magento\Cron\Model\Schedule::STATUS_SUCCESS => 'notice',
+            default => 'critical',
+        };
 
         return $level;
     }
@@ -199,8 +189,8 @@ class Timeline extends \Magento\Backend\Block\Template
             . "</td></tr>";
 
         if ($status== "success") {
-            $timeFirst  = strtotime($start);
-            $timeSecond = strtotime($end);
+            $timeFirst  = strtotime((string) $start);
+            $timeSecond = strtotime((string) $end);
             $differenceInSeconds = $timeSecond - $timeFirst;
 
             $tooltip .= "<tr><td>"

--- a/Controller/Adminhtml/Cron/LongJobChecker.php
+++ b/Controller/Adminhtml/Cron/LongJobChecker.php
@@ -62,7 +62,7 @@ class LongJobChecker extends \Magento\Backend\App\Action
     public function execute()
     {
         $collection = $this->scheduleCollectionFactory->create();
-        $time = strftime('%Y-%m-%d %H:%M:%S', $this->dateTime->gmtTimestamp($this->timePeriod));
+        $time = date('Y-m-d H:i:s', $this->dateTime->gmtTimestamp($this->timePeriod));
 
         $jobs = $collection->addFieldToFilter('status', \Magento\Cron\Model\Schedule::STATUS_RUNNING)
             ->addFieldToFilter(
@@ -79,7 +79,7 @@ class LongJobChecker extends \Magento\Backend\App\Action
         foreach ($jobs as $job) {
             $pid = $job->getPid();
 
-            $finished_at = strftime('%Y-%m-%d %H:%M:%S', $this->dateTime->gmtTimestamp());
+            $finished_at = date('Y-m-d H:i:s', $this->dateTime->gmtTimestamp());
             if (function_exists('posix_getsid') && posix_getsid($pid) === false) {
                 $job->setData('status', \Magento\Cron\Model\Schedule::STATUS_ERROR);
                 $job->setData('messages', __('Execution stopped due to some error.'));

--- a/Controller/Adminhtml/Cron/Sendemail.php
+++ b/Controller/Adminhtml/Cron/Sendemail.php
@@ -127,7 +127,7 @@ class Sendemail extends \Magento\Backend\App\Action
             $emailItems['missedJobs']    = $this->getMissedCronJob();
 
             $receiverEmailConfig = $this->scopeConfig->getValue(self::XML_PATH_EMAIL_RECIPIENT, \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
-            $receiverEmailIds = explode(',', $receiverEmailConfig);
+            $receiverEmailIds = explode(',', (string) $receiverEmailConfig);
 
             if (!empty($receiverEmailIds) && (!empty($emailItems['errorMessages']->getData()) || !empty($emailItems['missedJobs']->getData()))) {
                 try {

--- a/Controller/Adminhtml/Job/MassScheduleNow.php
+++ b/Controller/Adminhtml/Job/MassScheduleNow.php
@@ -114,11 +114,11 @@ class MassScheduleNow extends \Magento\Backend\App\Action
 
                     $magentoVersion = $this->scheduleHelper->getMagentoversion();
                     if (version_compare($magentoVersion, "2.2.0") >= 0) {
-                        $createdAt  = strftime('%Y-%m-%d %H:%M:%S', $this->dateTime->gmtTimestamp());
-                        $scheduleAt = strftime('%Y-%m-%dT%H:%M:%S', $this->dateTime->gmtTimestamp());
+                        $createdAt  = date('Y-m-d H:i:s', $this->dateTime->gmtTimestamp());
+                        $scheduleAt = date('Y-m-d H:i:s', $this->dateTime->gmtTimestamp());
                     } else {
-                        $createdAt  = strftime('%Y-%m-%d %H:%M:%S', $this->timezone->scopeTimeStamp());
-                        $scheduleAt = strftime('%Y-%m-%dT%H:%M:%S', $this->timezone->scopeTimeStamp());
+                        $createdAt  = date('Y-m-d H:i:s', $this->timezone->scopeTimeStamp());
+                        $scheduleAt = date('Y-m-d H:i:s', $this->timezone->scopeTimeStamp());
                     }
 
                     $collection->setData('job_code', $jobCode);

--- a/Controller/Adminhtml/Job/Save.php
+++ b/Controller/Adminhtml/Job/Save.php
@@ -66,7 +66,7 @@ class Save extends \Magento\Backend\App\Action
             if ($data) {
                 $data = $this->jobHelper->trimArray($data);
                 #Cron Expression Array
-                $cronExprArray = $this->jobHelper->trimArray(explode(',', $data['schedule']));
+                $cronExprArray = $this->jobHelper->trimArray(explode(',', (string) $data['schedule']));
                 $jobData = $this->jobHelper->getJobData();
                 $flagMultipleExpression = false;
 

--- a/Controller/Adminhtml/Schedule/MassKill.php
+++ b/Controller/Adminhtml/Schedule/MassKill.php
@@ -119,7 +119,7 @@ class MassKill extends \Magento\Backend\App\Action
                 if (function_exists('posix_getsid') && posix_getsid($pid) === false) {
                     $errorScheduleIds[] = $scheduleId;
                 } else {
-                    $finished_at = strftime('%Y-%m-%d %H:%M:%S', $this->dateTime->gmtTimestamp());
+                    $finished_at = date('Y-m-d H:i:s', $this->dateTime->gmtTimestamp());
                     $dbrunningjobs->setData('status', self::STATUS_KILLED);
                     $dbrunningjobs->setData('messages', __('It is killed by admin.'));
                     $dbrunningjobs->setData('finished_at', $finished_at);

--- a/Controller/Adminhtml/Validation/ClassExistance.php
+++ b/Controller/Adminhtml/Validation/ClassExistance.php
@@ -40,7 +40,7 @@ class ClassExistance extends \Magento\Backend\App\Action
     {
         if ($this->getRequest()->isXmlHttpRequest()) {
             $data = $this->getRequest()->getPostValue();
-            $classpath = trim($data['classpath']);
+            $classpath = trim((string) $data['classpath']);
             $resultJson = $this->resultFactory->create(ResultFactory::TYPE_JSON);
             $result = false;
 

--- a/Controller/Adminhtml/Validation/CronExpression.php
+++ b/Controller/Adminhtml/Validation/CronExpression.php
@@ -40,7 +40,7 @@ class CronExpression extends \Magento\Backend\App\Action
     {
         if ($this->getRequest()->isXmlHttpRequest()) {
             $data = $this->getRequest()->getPostValue();
-            $exprArray = explode(',', $data['expression']);
+            $exprArray = explode(',', (string) $data['expression']);
             $resultJson = $this->resultFactory->create(ResultFactory::TYPE_JSON);
             $result = true;
             foreach ($exprArray as $expr) {

--- a/Controller/Adminhtml/Validation/MethodExistance.php
+++ b/Controller/Adminhtml/Validation/MethodExistance.php
@@ -40,8 +40,8 @@ class MethodExistance extends \Magento\Backend\App\Action
     {
         if ($this->getRequest()->isXmlHttpRequest()) {
             $data = $this->getRequest()->getPostValue();
-            $classpath = trim($data['classpath']);
-            $methodname = trim($data['methodname']);
+            $classpath = trim((string) $data['classpath']);
+            $methodname = trim((string) $data['methodname']);
             $resultJson = $this->resultFactory->create(ResultFactory::TYPE_JSON);
             $result = false;
 

--- a/Controller/Adminhtml/Validation/UniqueJobCode.php
+++ b/Controller/Adminhtml/Validation/UniqueJobCode.php
@@ -48,7 +48,7 @@ class UniqueJobCode extends \Magento\Backend\App\Action
     {
         if ($this->getRequest()->isXmlHttpRequest()) {
             $data = $this->getRequest()->getPostValue();
-            $jobcode = trim($data['jobcode']);
+            $jobcode = trim((string) $data['jobcode']);
 
             $data = array_values($this->jobHelper->getJobData());
             $existingjobcode = array_column($data, 'code');

--- a/Helper/Cronjob.php
+++ b/Helper/Cronjob.php
@@ -181,9 +181,7 @@ class Cronjob extends \Magento\Framework\App\Helper\AbstractHelper
         $result = [];
         #filters
         foreach ($filters as $column => $value) {
-            $data = array_filter($data, function ($item) use ($column, $value) {
-                return stripos($item[$column], $value) !== false;
-            });
+            $data = array_filter($data, fn($item) => stripos((string) $item[$column], (string) $value) !== false);
         }
 
         if (!empty($data)) {

--- a/Helper/Schedule.php
+++ b/Helper/Schedule.php
@@ -125,7 +125,7 @@ class Schedule extends \Magento\Framework\App\Helper\AbstractHelper
         $matches = [];
         preg_match('/(\d+-\d+-\d+)T(\d+:\d+)/', (string) $time, $matches);
         $time = $matches[1] . " " . $matches[2];
-        return strftime('%Y-%m-%d %H:%M:00', strtotime($time));
+        return date('Y-m-d H:i:s', strtotime($time));
     }
 
     /**

--- a/Helper/Schedule.php
+++ b/Helper/Schedule.php
@@ -123,7 +123,7 @@ class Schedule extends \Magento\Framework\App\Helper\AbstractHelper
     public function filterTimeInput($time)
     {
         $matches = [];
-        preg_match('/(\d+-\d+-\d+)T(\d+:\d+)/', $time, $matches);
+        preg_match('/(\d+-\d+-\d+)T(\d+:\d+)/', (string) $time, $matches);
         $time = $matches[1] . " " . $matches[2];
         return strftime('%Y-%m-%d %H:%M:00', strtotime($time));
     }
@@ -140,7 +140,7 @@ class Schedule extends \Magento\Framework\App\Helper\AbstractHelper
         } else {
             $currentTime = (int)$this->datetime->date('U') + $this->datetime->getGmtOffset('hours') * 60 * 60;
         }
-        $lastCronStatus = strtotime($this->scheduleCollectionFactory->create()->getLastCronStatus());
+        $lastCronStatus = strtotime((string) $this->scheduleCollectionFactory->create()->getLastCronStatus());
         if ($lastCronStatus != null) {
             $diff = floor(($currentTime - $lastCronStatus) / 60);
             if ($diff > 5) {
@@ -164,7 +164,7 @@ class Schedule extends \Magento\Framework\App\Helper\AbstractHelper
      */
     public function getMagentoversion()
     {
-        $explodedVersion = explode("-", $this->productMetaData->getVersion());
+        $explodedVersion = explode("-", (string) $this->productMetaData->getVersion());
         $magentoversion = $explodedVersion[0];
 
         return $magentoversion;

--- a/Observer/ProcessCronQueueObserver.php
+++ b/Observer/ProcessCronQueueObserver.php
@@ -92,13 +92,14 @@ class ProcessCronQueueObserver extends \Magento\Cron\Observer\ProcessCronQueueOb
         \Magento\Framework\Lock\LockManagerInterface $lockManager,
         \Magento\Framework\Event\ManagerInterface $eventManager,
         \Magento\Cron\Model\DeadlockRetrierInterface $retrier,
+        \Laminas\Http\PhpEnvironment\Request $environment,
         \KiwiCommerce\CronScheduler\Helper\Schedule $scheduleHelper,
         \KiwiCommerce\CronScheduler\Helper\Cronjob $jobHelper
     ) {
         parent::__construct(
             $objectManager, $scheduleFactory, $cache, $config, $scopeConfig,
             $request, $shell, $dateTime, $phpExecutableFinderFactory, $logger,
-            $state, $statFactory, $lockManager, $eventManager, $retrier);
+            $state, $statFactory, $lockManager, $eventManager, $retrier, $environment);
         $this->logger = $logger;
         $this->state = $state;
         $this->statProfiler = $statFactory->create();

--- a/Observer/ProcessCronQueueObserver.php
+++ b/Observer/ProcessCronQueueObserver.php
@@ -134,8 +134,9 @@ class ProcessCronQueueObserver extends \Magento\Cron\Observer\ProcessCronQueueOb
                 sprintf('Invalid callback: %s::%s can\'t be called', $jobConfig['instance'], $jobConfig['method'])
             );
         }
+        //  $scheduledTime) is used to avoid time zone issues
 
-        $schedule->setExecutedAt(strftime('%Y-%m-%d %H:%M:%S', $this->dateTime->gmtTimestamp()))->save();
+        $schedule->setExecutedAt(date('Y-m-d H:i:s', $this->dateTime->gmtTimestamp()))->save();
 
         $this->startProfiling();
         try {
@@ -167,8 +168,8 @@ class ProcessCronQueueObserver extends \Magento\Cron\Observer\ProcessCronQueueOb
         $schedule->setStatus(
             Schedule::STATUS_SUCCESS
         )->setFinishedAt(
-            strftime(
-                '%Y-%m-%d %H:%M:%S',
+            date(
+                'Y-m-d H:i:s',
                 $this->dateTime->gmtTimestamp()
             )
         );

--- a/Ui/Component/Listing/Column/Status/Options.php
+++ b/Ui/Component/Listing/Column/Status/Options.php
@@ -55,7 +55,7 @@ class Options implements \Magento\Framework\Data\OptionSourceInterface
             foreach ($scheduleTaskStatuses as $scheduleTaskStatus) {
                 $status = $scheduleTaskStatus->getStatus();
                 $this->options[] = [
-                    "label" => __(strtoupper($status)),
+                    "label" => __(strtoupper((string) $status)),
                     "value" => $status
                 ];
             }

--- a/Ui/DataProvider/JobProvider.php
+++ b/Ui/DataProvider/JobProvider.php
@@ -128,9 +128,7 @@ class JobProvider extends \Magento\Ui\DataProvider\AbstractDataProvider
 
         #filters
         foreach ($this->likeFilters as $column => $value) {
-            $data = array_filter($data, function ($item) use ($column, $value) {
-                return stripos($item[$column], $value) !== false;
-            });
+            $data = array_filter($data, fn($item) => stripos((string) $item[$column], (string) $value) !== false);
         }
 
         #pagination

--- a/Ui/DataProvider/JobProvider.php
+++ b/Ui/DataProvider/JobProvider.php
@@ -120,9 +120,9 @@ class JobProvider extends \Magento\Ui\DataProvider\AbstractDataProvider
         $sortDir = $this->sortDir;
         usort($data, function ($a, $b) use ($sortField, $sortDir) {
             if ($sortDir == "asc") {
-                return $a[$sortField] > $b[$sortField];
+                return ($a[$sortField] > $b[$sortField]) ? -1 : (($a[$sortField] <  $b[$sortField]) ? 1 : 0);
             } else {
-                return $a[$sortField] < $b[$sortField];
+                return ($a[$sortField] < $b[$sortField]) ? -1 : (($a[$sortField] >  $b[$sortField]) ? 1 : 0);
             }
         });
 

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\LevelSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([LevelSetList::UP_TO_PHP_82]);
+};

--- a/rector.php
+++ b/rector.php
@@ -6,5 +6,5 @@ use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->sets([LevelSetList::UP_TO_PHP_82]);
+    $rectorConfig->sets([LevelSetList::UP_TO_PHP_83]);
 };


### PR DESCRIPTION
This is for Magento 2.4.4 compatibility (possibly earlier versions, but I'm running 2.4.4-p1). This observer is missing a required include in the parent's constructor.

Also adding tweaks for PHP 8.2 and 8.3 support.